### PR TITLE
[Feat] chat system

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 
     implementation 'org.hibernate:hibernate-spatial:6.6.15.Final'
     implementation 'org.locationtech.jts:jts-core:1.19.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 sourceSets {

--- a/backend/src/main/java/com/team3/airdnd/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/controller/ChatController.java
@@ -12,13 +12,13 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@Controller //HTTP 요청이 아니라 STOMP WebSocket 메시지 처리용 어노테이션
+@Controller
 public class ChatController {
 
 	private final ChatService chatService;
 
-	@MessageMapping("/chat/message") // /pub/chat/message 로 요청 들어옴
-	@SendTo("/sub/chat/accommodation/{accommodationId}") // 이걸 구독하고 있는 클라이언트에게 보냄
+	@MessageMapping("/chat/message") // 클라이언트가 pub/chat/message로 전송
+	@SendTo("/sub/chat/room/{reservationId}") // 예약 ID 기준으로 구독
 	public ChatMessageDto sendMessage(ChatMessageDto message) {
 		chatService.saveMessage(message);
 		return message;

--- a/backend/src/main/java/com/team3/airdnd/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/controller/ChatRestController.java
@@ -5,10 +5,13 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.team3.airdnd.chat.dto.ChatMessageResponseDto;
+import com.team3.airdnd.chat.dto.ChatRoomWithUnreadCountDto;
 import com.team3.airdnd.chat.service.ChatService;
 import com.team3.airdnd.global.dto.ResponseDto;
 
@@ -25,5 +28,24 @@ public class ChatRestController {
 	public ResponseEntity<ResponseDto<List<ChatMessageResponseDto>>> getMessages(@PathVariable Long reservationId) {
 		List<ChatMessageResponseDto> messages = chatService.getMessageList(reservationId);
 		return ResponseDto.ok(messages);
+	}
+
+	// 안읽은 메시지 읽음 처리
+	@PostMapping("/rooms/{roomId}/read")
+	public ResponseEntity<Void> markMessagesAsRead(@PathVariable Long roomId) {
+		Long userId = 1L;
+		chatService.markMessagesAsRead(roomId, userId);
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/rooms")
+	public ResponseEntity<ResponseDto<List<ChatRoomWithUnreadCountDto>>> getMyChatRooms(
+		@RequestParam(value = "unreadOnly", required = false, defaultValue = "false") boolean unreadOnly
+	) {
+		//unreadOnly=false: 전체 채팅방 목록 + 각 채팅방의 읽지 않은 메시지 수
+		//unreadOnly=true: 읽지 않은 메시지가 있는 채팅방만
+		Long userId = 1L;
+		List<ChatRoomWithUnreadCountDto> chatRooms = chatService.getMyChatRooms(userId, unreadOnly);
+		return ResponseDto.ok(chatRooms);
 	}
 }

--- a/backend/src/main/java/com/team3/airdnd/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/controller/ChatRestController.java
@@ -21,9 +21,9 @@ public class ChatRestController {
 
 	private final ChatService chatService;
 
-	@GetMapping("/accommodations/{accommodationId}/messages")
-	public ResponseEntity<ResponseDto<List<ChatMessageResponseDto>>> getMessages(@PathVariable Long accommodationId) {
-		List<ChatMessageResponseDto> messages = chatService.getMessageList(accommodationId);
+	@GetMapping("/rooms/{reservationId}/messages")
+	public ResponseEntity<ResponseDto<List<ChatMessageResponseDto>>> getMessages(@PathVariable Long reservationId) {
+		List<ChatMessageResponseDto> messages = chatService.getMessageList(reservationId);
 		return ResponseDto.ok(messages);
 	}
 }

--- a/backend/src/main/java/com/team3/airdnd/chat/dto/ChatMessageDto.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/dto/ChatMessageDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ChatMessageDto {
-	private Long accommodationId;
+	private Long reservationId;
 	private Long senderId;
 	private String content;
 }

--- a/backend/src/main/java/com/team3/airdnd/chat/dto/ChatRoomWithUnreadCountDto.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/dto/ChatRoomWithUnreadCountDto.java
@@ -1,0 +1,32 @@
+package com.team3.airdnd.chat.dto;
+
+import com.team3.airdnd.chat.domain.ChatRoom;
+import com.team3.airdnd.user.domain.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomWithUnreadCountDto {
+	private Long roomId;
+	private String otherUserName;
+	private long unreadCount;
+
+	public static ChatRoomWithUnreadCountDto of(ChatRoom room, Long currentUserId, long unreadCount) {
+		User otherUser = getOtherUser(room, currentUserId);
+		return new ChatRoomWithUnreadCountDto(
+			room.getId(),
+			otherUser.getUsername(),
+			unreadCount
+		);
+	}
+
+	private static User getOtherUser(ChatRoom room, Long currentUserId) {
+		if (room.getGuest().getId().equals(currentUserId)) {
+			return room.getHost();
+		} else {
+			return room.getGuest();
+		}
+	}
+}

--- a/backend/src/main/java/com/team3/airdnd/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/repository/ChatMessageRepository.java
@@ -8,7 +8,6 @@ import com.team3.airdnd.chat.domain.ChatRoom;
 import com.team3.airdnd.chat.domain.Message;
 
 public interface ChatMessageRepository extends JpaRepository<Message, Long> {
-
-	// 시간순 정렬
+	
 	List<Message> findByChatRoomOrderBySentAtAsc(ChatRoom chatRoom);
 }

--- a/backend/src/main/java/com/team3/airdnd/chat/repository/ChatRoomRepository.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/repository/ChatRoomRepository.java
@@ -1,8 +1,11 @@
 package com.team3.airdnd.chat.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.team3.airdnd.chat.domain.ChatRoom;
 import com.team3.airdnd.reservation.domain.Reservation;
@@ -11,4 +14,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 	Optional<ChatRoom> findByReservationId(Long reservationId);
 
 	boolean existsByReservation(Reservation reservation);
+
+	@Query("""
+		    SELECT cr FROM ChatRoom cr
+		    WHERE cr.guest.id = :userId OR cr.host.id = :userId
+		""")
+	List<ChatRoom> findByUser(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/team3/airdnd/chat/repository/ChatRoomRepository.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/repository/ChatRoomRepository.java
@@ -5,9 +5,10 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.team3.airdnd.chat.domain.ChatRoom;
+import com.team3.airdnd.reservation.domain.Reservation;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-
-	// 예약 ID 기준으로 채팅방 찾기
 	Optional<ChatRoom> findByReservationId(Long reservationId);
+
+	boolean existsByReservation(Reservation reservation);
 }

--- a/backend/src/main/java/com/team3/airdnd/chat/service/ChatRedisService.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/service/ChatRedisService.java
@@ -1,0 +1,33 @@
+package com.team3.airdnd.chat.service;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRedisService {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public void incrementUnreadCount(Long roomId, Long targetUserId) {
+		String key = getUnreadKey(roomId, targetUserId);
+		redisTemplate.opsForValue().increment(key);
+	}
+
+	public void clearUnreadCount(Long roomId, Long userId) {
+		String key = getUnreadKey(roomId, userId);
+		redisTemplate.delete(key);
+	}
+
+	public long getUnreadCount(Long roomId, Long userId) {
+		String key = getUnreadKey(roomId, userId);
+		Object value = redisTemplate.opsForValue().get(key);
+		return value != null ? Long.parseLong(value.toString()) : 0;
+	}
+
+	private String getUnreadKey(Long roomId, Long userId) {
+		return "unread:room:" + roomId + ":user:" + userId;
+	}
+}

--- a/backend/src/main/java/com/team3/airdnd/chat/service/ChatService.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/service/ChatService.java
@@ -12,23 +12,26 @@ import com.team3.airdnd.chat.dto.ChatMessageDto;
 import com.team3.airdnd.chat.dto.ChatMessageResponseDto;
 import com.team3.airdnd.chat.repository.ChatMessageRepository;
 import com.team3.airdnd.chat.repository.ChatRoomRepository;
+import com.team3.airdnd.reservation.domain.Reservation;
 import com.team3.airdnd.user.domain.User;
 import com.team3.airdnd.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
-@Transactional
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class ChatService {
 
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatMessageRepository chatMessageRepository;
 	private final UserRepository userRepository;
 
+	// 메시지 저장
+	@Transactional
 	public void saveMessage(ChatMessageDto dto) {
-		ChatRoom room = chatRoomRepository.findById(dto.getAccommodationId())
+		ChatRoom room = chatRoomRepository.findByReservationId(dto.getReservationId())
 			.orElseThrow(() -> new RuntimeException("채팅방 없음"));
+
 		User sender = userRepository.findById(dto.getSenderId())
 			.orElseThrow(() -> new RuntimeException("유저 없음"));
 
@@ -42,9 +45,10 @@ public class ChatService {
 		chatMessageRepository.save(message);
 	}
 
+	// 메시지 목록 조회
 	@Transactional(readOnly = true)
-	public List<ChatMessageResponseDto> getMessageList(Long accommodationId) {
-		ChatRoom room = chatRoomRepository.findById(accommodationId)
+	public List<ChatMessageResponseDto> getMessageList(Long reservationId) {
+		ChatRoom room = chatRoomRepository.findByReservationId(reservationId)
 			.orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
 
 		List<Message> messages = chatMessageRepository.findByChatRoomOrderBySentAtAsc(room);
@@ -58,5 +62,19 @@ public class ChatService {
 				.sentAt(msg.getSentAt())
 				.build())
 			.toList();
+	}
+
+	// 채팅방 생성
+	@Transactional
+	public void createRoomIfNotExists(Reservation reservation) {
+		if (chatRoomRepository.existsByReservation(reservation))
+			return;
+
+		ChatRoom room = ChatRoom.builder()
+			.guest(reservation.getGuest())
+			.host(reservation.getAccommodation().getHost())
+			.reservation(reservation)
+			.build();
+		chatRoomRepository.save(room);
 	}
 }

--- a/backend/src/main/java/com/team3/airdnd/chat/service/ChatService.java
+++ b/backend/src/main/java/com/team3/airdnd/chat/service/ChatService.java
@@ -10,6 +10,7 @@ import com.team3.airdnd.chat.domain.ChatRoom;
 import com.team3.airdnd.chat.domain.Message;
 import com.team3.airdnd.chat.dto.ChatMessageDto;
 import com.team3.airdnd.chat.dto.ChatMessageResponseDto;
+import com.team3.airdnd.chat.dto.ChatRoomWithUnreadCountDto;
 import com.team3.airdnd.chat.repository.ChatMessageRepository;
 import com.team3.airdnd.chat.repository.ChatRoomRepository;
 import com.team3.airdnd.reservation.domain.Reservation;
@@ -25,6 +26,7 @@ public class ChatService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatMessageRepository chatMessageRepository;
 	private final UserRepository userRepository;
+	private final ChatRedisService chatRedisService;
 
 	// 메시지 저장
 	@Transactional
@@ -43,6 +45,31 @@ public class ChatService {
 			.build();
 
 		chatMessageRepository.save(message);
+
+		Long receiverId = getOtherUserId(room, sender.getId());
+		chatRedisService.incrementUnreadCount(room.getId(), receiverId);
+	}
+
+	private Long getOtherUserId(ChatRoom room, Long senderId) {
+		return room.getGuest().getId().equals(senderId)
+			? room.getHost().getId()
+			: room.getGuest().getId();
+	}
+
+	public void markMessagesAsRead(Long roomId, Long userId) {
+		chatRedisService.clearUnreadCount(roomId, userId);
+	}
+
+	public List<ChatRoomWithUnreadCountDto> getMyChatRooms(Long userId, boolean unreadOnly) {
+		List<ChatRoom> rooms = chatRoomRepository.findByUser(userId); // guest or host
+
+		return rooms.stream()
+			.map(room -> {
+				long unread = chatRedisService.getUnreadCount(room.getId(), userId);
+				return ChatRoomWithUnreadCountDto.of(room, userId, unread);
+			})
+			.filter(dto -> !unreadOnly || dto.getUnreadCount() > 0) //false면 모두 반환
+			.toList();
 	}
 
 	// 메시지 목록 조회

--- a/backend/src/main/java/com/team3/airdnd/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/service/ReservationService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.team3.airdnd.accommodation.domain.Accommodation;
 import com.team3.airdnd.accommodation.repository.AccommodationRepository;
+import com.team3.airdnd.chat.service.ChatService;
 import com.team3.airdnd.global.exception.CommonException;
 import com.team3.airdnd.global.exception.ErrorCode;
 import com.team3.airdnd.payment.repository.PaymentRepository;
@@ -33,6 +34,7 @@ public class ReservationService {
 	private final ReservationRepository reservationRepository;
 	private final ReservedDateRepository reservedDateRepository;
 	private final PaymentRepository paymentRepository;
+	private final ChatService chatService;
 
 	public ReservationResponseDto.ReservationInfoResponseDto getReservationInfo(Long accommodationId, LocalDate checkIn,
 		LocalDate checkOut) {
@@ -81,6 +83,8 @@ public class ReservationService {
 			.build();
 
 		reservationRepository.save(reservation);
+
+		chatService.createRoomIfNotExists(reservation);
 
 		return ReservationResponseDto.CreateReservationResponseDto.builder()
 			.reservationId(reservation.getId())

--- a/backend/src/test/java/com/team3/airdnd/chat/ChatServiceTest.java
+++ b/backend/src/test/java/com/team3/airdnd/chat/ChatServiceTest.java
@@ -1,0 +1,75 @@
+package com.team3.airdnd.chat;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.team3.airdnd.chat.domain.ChatRoom;
+import com.team3.airdnd.chat.domain.Message;
+import com.team3.airdnd.chat.dto.ChatMessageDto;
+import com.team3.airdnd.chat.repository.ChatMessageRepository;
+import com.team3.airdnd.chat.repository.ChatRoomRepository;
+import com.team3.airdnd.chat.service.ChatService;
+import com.team3.airdnd.reservation.domain.Reservation;
+import com.team3.airdnd.reservation.repository.ReservationRepository;
+import com.team3.airdnd.user.domain.User;
+import com.team3.airdnd.user.repository.UserRepository;
+
+@SpringBootTest
+@Transactional
+class ChatServiceTest {
+
+	@Autowired
+	private ChatService chatService;
+
+	@Autowired
+	private ChatRoomRepository chatRoomRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ReservationRepository reservationRepository;
+
+	@Autowired
+	private ChatMessageRepository chatMessageRepository;
+
+	@Test
+	@DisplayName("채팅방 생성이후 채팅방이 생성되고, 서로의 메시지가 DB에 저장되어야 한다.")
+	void testMessageSave() {
+		// Given
+		Reservation reservation = reservationRepository.findAll().get(0);
+		chatService.createRoomIfNotExists(reservation);
+
+		ChatRoom chatRoom = chatRoomRepository.findByReservationId(reservation.getId())
+			.orElseThrow();
+
+		User sender = userRepository.findById(reservation.getGuest().getId())
+			.orElseThrow();
+
+		chatService.saveMessage(ChatMessageDto.builder()
+			.reservationId(reservation.getId())
+			.senderId(reservation.getGuest().getId())
+			.content("게스트: 안녕하세요!")
+			.build());
+
+		chatService.saveMessage(ChatMessageDto.builder()
+			.reservationId(reservation.getId())
+			.senderId(reservation.getAccommodation().getHost().getId())
+			.content("호스트: 반갑습니다.")
+			.build());
+
+		// When
+		List<Message> messages = chatMessageRepository.findByChatRoomOrderBySentAtAsc(chatRoom);
+
+		assertThat(messages).hasSize(2);
+		assertThat(messages.get(0).getContent()).contains("안녕하세요");
+		assertThat(messages.get(1).getContent()).contains("반갑습니다");
+	}
+}


### PR DESCRIPTION
1. 채팅방 생성
- 예약이 완료되면 채팅방이 자동 생성
- 동일한 예약에 대해 중복 생성되지 않도록 방지 로직 포함.

2. 실시간 채팅 (WebSocket + STOMP)
- 클라이언트가 /pub/chat/message로 메시지를 전송하면,
- 서버는 해당 예약 ID 기반으로 /sub/chat/accommodation/{reservationId} 구독자에게 메시지를 전달합니다.
- 메시지는 DB에도 저장됩니다.

3. 채팅 메시지 조회 API
- REST API /api/chat/rooms/{reservationId}/messages를 통해 해당 채팅방(예약 ID)의 전체 메시지를 시간순으로 조회

4. 읽음 처리 및 Redis를 이용한 unread count 관리
- 메시지를 받는 사용자의 읽지 않은 메시지 수를 Redis에 저장
- 사용자가 채팅방에 입장할 때 /api/chat/rooms/{roomId}/read API를 호출하면 해당 수치를 초기화합니다.
- Redis의 키 구조는 chat:unread:{roomId}:{userId} 형태

5. 채팅방 리스트 + 안 읽은 메시지 수 조회
- 사용자가 속한 채팅방 전체를 반환하면서 각 채팅방마다 안 읽은 메시지 수를 포함
- unreadOnly 파라미터를 통해 “읽지 않은 메시지가 있는 채팅방만 조회”하는 필터링도 가능