### PR TITLE
[Feat] 예약 조회 기능 개발

### DIFF
--- a/backend/src/main/java/com/team3/airdnd/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/team3/airdnd/payment/service/PaymentService.java
@@ -95,6 +95,7 @@ public class PaymentService {
 				paymentRepository.save(payment);
 
 				reservation.setStatus(Reservation.Status.CONFIRMED);
+				reservation.setCreatedAt(LocalDateTime.now());
 				reservationRepository.save(reservation);
 
 				return payment;

--- a/backend/src/main/java/com/team3/airdnd/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/controller/ReservationController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.team3.airdnd.reservation.dto.GuestReservationDto;
+import com.team3.airdnd.reservation.dto.HostReservationDto;
 import com.team3.airdnd.reservation.dto.ReservationRequestDto;
 import com.team3.airdnd.reservation.dto.ReservationResponseDto;
 import com.team3.airdnd.reservation.service.ReservationService;
@@ -67,6 +68,21 @@ public class ReservationController {
 	@GetMapping("/guest/{guestId}/confirmed")
 	public List<GuestReservationDto> getConfirmedReservationsByGuest(@PathVariable Long guestId) {
 		return reservationService.getConfirmedReservationsByGuest(guestId);
+	}
+
+	//호스트가 자신이 등록한 숙소들의 예약을 최신순으로 조회
+	@GetMapping("/host/{hostId}")
+	public List<HostReservationDto> getReservationsByHost(@PathVariable Long hostId) {
+		return reservationService.getReservationsByHost(hostId);
+	}
+
+	//호스트의 특정 숙소에 해당하는 예약 목록을 조회
+	@GetMapping("/host/{hostId}/accommodation/{accommodationId}")
+	public List<HostReservationDto> getReservationsByHostAndAccommodation(
+		@PathVariable Long hostId,
+		@PathVariable Long accommodationId
+	) {
+		return reservationService.getReservationsByHostAndAccommodation(hostId, accommodationId);
 	}
 
 }

--- a/backend/src/main/java/com/team3/airdnd/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/controller/ReservationController.java
@@ -1,6 +1,7 @@
 package com.team3.airdnd.reservation.controller;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.team3.airdnd.reservation.dto.GuestReservationDto;
 import com.team3.airdnd.reservation.dto.ReservationRequestDto;
 import com.team3.airdnd.reservation.dto.ReservationResponseDto;
 import com.team3.airdnd.reservation.service.ReservationService;
@@ -60,4 +62,11 @@ public class ReservationController {
 		reservationService.cancelReservation(reservationId);
 		return ResponseEntity.ok(null);
 	}
+
+	//게스트 예약 조회
+	@GetMapping("/guest/{guestId}/confirmed")
+	public List<GuestReservationDto> getConfirmedReservationsByGuest(@PathVariable Long guestId) {
+		return reservationService.getConfirmedReservationsByGuest(guestId);
+	}
+
 }

--- a/backend/src/main/java/com/team3/airdnd/reservation/domain/Reservation.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/domain/Reservation.java
@@ -1,6 +1,9 @@
 package com.team3.airdnd.reservation.domain;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
 
 import com.team3.airdnd.accommodation.domain.Accommodation;
 import com.team3.airdnd.user.domain.User;
@@ -60,6 +63,10 @@ public class Reservation {
 
 	@Column(name = "total_price", nullable = false)
 	private Long totalPrice; //순수 숙박비
+
+	@CreatedDate
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
 
 	public enum Status {
 		PENDING, CONFIRMED, CANCELLED

--- a/backend/src/main/java/com/team3/airdnd/reservation/dto/GuestReservationDto.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/dto/GuestReservationDto.java
@@ -1,0 +1,34 @@
+package com.team3.airdnd.reservation.dto;
+
+import java.time.LocalDate;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.team3.airdnd.reservation.domain.Reservation;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GuestReservationDto {
+	private Long reservationId;
+	private String orderId;
+	private String accommodationName;
+	private LocalDate checkIn;
+	private LocalDate checkOut;
+	private Long totalPrice;
+	private Reservation.Status status;
+
+	@QueryProjection
+	public GuestReservationDto(Long reservationId, String orderId, String accommodationName,
+		LocalDate checkIn, LocalDate checkOut,
+		Long totalPrice, Reservation.Status status) {
+		this.reservationId = reservationId;
+		this.orderId = orderId;
+		this.accommodationName = accommodationName;
+		this.checkIn = checkIn;
+		this.checkOut = checkOut;
+		this.totalPrice = totalPrice;
+		this.status = status;
+	}
+}

--- a/backend/src/main/java/com/team3/airdnd/reservation/dto/HostReservationDto.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/dto/HostReservationDto.java
@@ -11,31 +11,34 @@ import lombok.Getter;
 
 @Builder
 @Getter
-public class GuestReservationDto {
+public class HostReservationDto {
 	private Long reservationId;
+	private String guestName;
 	private String orderId;
 	private String accommodationName;
 	private String coverImageUrl;
 	private LocalDate checkIn;
 	private LocalDate checkOut;
-	private Long totalPrice;
-	private Long serviceFee;
-	private LocalDateTime createdAt;
 	private Reservation.Status status;
+	private Long serviceFee;
+	private Long totalPrice;
+	private LocalDateTime createdAt;
 
 	@QueryProjection
-	public GuestReservationDto(Long reservationId, String orderId, String accommodationName, String coverImageUrl,
-		LocalDate checkIn, LocalDate checkOut,
-		Long totalPrice, Long serviceFee, LocalDateTime createdAt, Reservation.Status status) {
+	public HostReservationDto(Long reservationId, String guestName, String orderId, String accommodationName,
+		String coverImageUrl,
+		LocalDate checkIn, LocalDate checkOut, Reservation.Status status,
+		Long serviceFee, Long totalPrice, LocalDateTime createdAt) {
 		this.reservationId = reservationId;
+		this.guestName = guestName;
 		this.orderId = orderId;
 		this.accommodationName = accommodationName;
 		this.coverImageUrl = coverImageUrl;
 		this.checkIn = checkIn;
 		this.checkOut = checkOut;
-		this.totalPrice = totalPrice;
-		this.serviceFee = serviceFee;
-		this.createdAt = createdAt;
 		this.status = status;
+		this.serviceFee = serviceFee;
+		this.totalPrice = totalPrice;
+		this.createdAt = createdAt;
 	}
 }

--- a/backend/src/main/java/com/team3/airdnd/reservation/query/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/query/ReservationQueryRepository.java
@@ -2,6 +2,7 @@ package com.team3.airdnd.reservation.query;
 
 import static com.team3.airdnd.accommodation.domain.QAccommodation.*;
 import static com.team3.airdnd.reservation.domain.QReservation.*;
+import static com.team3.airdnd.storedFile.domain.QStoredFile.*;
 
 import java.util.List;
 
@@ -10,7 +11,13 @@ import org.springframework.stereotype.Repository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.team3.airdnd.reservation.domain.Reservation;
 import com.team3.airdnd.reservation.dto.GuestReservationDto;
+import com.team3.airdnd.reservation.dto.HostReservationDto;
+
 import com.team3.airdnd.reservation.dto.QGuestReservationDto;
+import com.team3.airdnd.reservation.dto.QHostReservationDto;
+import com.team3.airdnd.storedFile.domain.StoredFile;
+import com.team3.airdnd.user.domain.QUser;
+
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,20 +27,29 @@ public class ReservationQueryRepository {
 
 	private final JPAQueryFactory queryFactory;
 
-
+	// 게스트의 예약 조회
 	public List<GuestReservationDto> findConfirmedReservationsByGuestId(Long guestId) {
 		return queryFactory
 			.select(new QGuestReservationDto(
 				reservation.id,
 				reservation.orderId,
 				accommodation.name,
+				storedFile.fileUrl,
 				reservation.checkIn,
 				reservation.checkOut,
 				reservation.totalPrice,
+				reservation.serviceFee,
+				reservation.createdAt,
 				reservation.status
 			))
 			.from(reservation)
 			.join(reservation.accommodation, accommodation)
+			.leftJoin(storedFile)
+			.on(
+				storedFile.targetType.eq(StoredFile.TargetType.ACCOMMODATION),
+				storedFile.targetId.eq(accommodation.id),
+				storedFile.fileOrder.eq(1)
+			)
 			.where(
 				reservation.guest.id.eq(guestId),
 				reservation.status.eq(Reservation.Status.CONFIRMED)
@@ -41,4 +57,70 @@ public class ReservationQueryRepository {
 			.fetch();
 	}
 
+	// 호스트의 모든 예약 조회
+	public List<HostReservationDto> findReservationsByHostId(Long hostId) {
+		QUser guestAlias = new QUser("guest");
+
+		return queryFactory
+			.select(new QHostReservationDto(
+				reservation.id,
+				guestAlias.username,
+				reservation.orderId,
+				accommodation.name,
+				storedFile.fileUrl,
+				reservation.checkIn,
+				reservation.checkOut,
+				reservation.status,
+				reservation.serviceFee,
+				reservation.totalPrice,
+				reservation.createdAt
+			))
+			.from(reservation)
+			.join(reservation.accommodation, accommodation)
+			.join(reservation.guest, guestAlias)
+			.leftJoin(storedFile)
+			.on(
+				storedFile.targetType.eq(StoredFile.TargetType.ACCOMMODATION),
+				storedFile.targetId.eq(accommodation.id),
+				storedFile.fileOrder.eq(1)
+			)
+			.where(accommodation.host.id.eq(hostId))
+			.orderBy(reservation.createdAt.desc())
+			.fetch();
+	}
+
+	// 호스트의 특정 숙소 예약 조회
+	public List<HostReservationDto> findReservationsByHostIdAndAccommodationId(Long hostId, Long accommodationId) {
+		QUser guestAlias = new QUser("guest");
+
+		return queryFactory
+			.select(new QHostReservationDto(
+				reservation.id,
+				guestAlias.username,
+				reservation.orderId,
+				accommodation.name,
+				storedFile.fileUrl,
+				reservation.checkIn,
+				reservation.checkOut,
+				reservation.status,
+				reservation.serviceFee,
+				reservation.totalPrice,
+				reservation.createdAt
+			))
+			.from(reservation)
+			.join(reservation.accommodation, accommodation)
+			.join(reservation.guest, guestAlias)
+			.leftJoin(storedFile)
+			.on(
+				storedFile.targetType.eq(StoredFile.TargetType.ACCOMMODATION),
+				storedFile.targetId.eq(accommodation.id),
+				storedFile.fileOrder.eq(1)
+			)
+			.where(
+				accommodation.host.id.eq(hostId),
+				accommodation.id.eq(accommodationId)
+			)
+			.orderBy(reservation.createdAt.desc())
+			.fetch();
+	}
 }

--- a/backend/src/main/java/com/team3/airdnd/reservation/query/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/query/ReservationQueryRepository.java
@@ -1,0 +1,44 @@
+package com.team3.airdnd.reservation.query;
+
+import static com.team3.airdnd.accommodation.domain.QAccommodation.*;
+import static com.team3.airdnd.reservation.domain.QReservation.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team3.airdnd.reservation.domain.Reservation;
+import com.team3.airdnd.reservation.dto.GuestReservationDto;
+import com.team3.airdnd.reservation.dto.QGuestReservationDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReservationQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+
+	public List<GuestReservationDto> findConfirmedReservationsByGuestId(Long guestId) {
+		return queryFactory
+			.select(new QGuestReservationDto(
+				reservation.id,
+				reservation.orderId,
+				accommodation.name,
+				reservation.checkIn,
+				reservation.checkOut,
+				reservation.totalPrice,
+				reservation.status
+			))
+			.from(reservation)
+			.join(reservation.accommodation, accommodation)
+			.where(
+				reservation.guest.id.eq(guestId),
+				reservation.status.eq(Reservation.Status.CONFIRMED)
+			)
+			.fetch();
+	}
+
+}

--- a/backend/src/main/java/com/team3/airdnd/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/service/ReservationService.java
@@ -21,6 +21,8 @@ import com.team3.airdnd.payment.repository.PaymentRepository;
 import com.team3.airdnd.reservation.domain.Reservation;
 import com.team3.airdnd.reservation.domain.ReservedDate;
 
+import com.team3.airdnd.reservation.dto.GuestReservationDto;
+import com.team3.airdnd.reservation.dto.HostReservationDto;
 import com.team3.airdnd.reservation.dto.ReservationRequestDto;
 import com.team3.airdnd.reservation.dto.ReservationResponseDto;
 import com.team3.airdnd.reservation.query.ReservationQueryRepository;
@@ -42,6 +44,7 @@ public class ReservationService {
 	private final PaymentRepository paymentRepository;
 	private final RedissonClient redissonClient;
 	private final ChatService chatService;
+	private final ReservationQueryRepository reservationQueryRepository;
 
 	public ReservationResponseDto.ReservationInfoResponseDto getReservationInfo(Long accommodationId, LocalDate checkIn,
 		LocalDate checkOut) {
@@ -216,7 +219,17 @@ public class ReservationService {
 		}
 	}
 	//게스트 예약 조회
-	//public List<GuestReservationDto> getConfirmedReservationsByGuest(Long guestId) {
-	//	return reservationQueryRepository.findConfirmedReservationsByGuestId(guestId);
-	//}
+	public List<GuestReservationDto> getConfirmedReservationsByGuest(Long guestId) {
+		return reservationQueryRepository.findConfirmedReservationsByGuestId(guestId);
+	}
+
+	//호스트가 자신이 등록한 숙소들의 예약을 최신순으로 조회
+	public List<HostReservationDto> getReservationsByHost(Long hostId) {
+		return reservationQueryRepository.findReservationsByHostId(hostId);
+	}
+
+	//호스트의 특정 숙소에 해당하는 예약 목록을 조회
+	public List<HostReservationDto> getReservationsByHostAndAccommodation(Long hostId, Long accommodationId) {
+		return reservationQueryRepository.findReservationsByHostIdAndAccommodationId(hostId, accommodationId);
+	}
 }

--- a/backend/src/main/java/com/team3/airdnd/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/team3/airdnd/reservation/service/ReservationService.java
@@ -20,8 +20,10 @@ import com.team3.airdnd.global.exception.ErrorCode;
 import com.team3.airdnd.payment.repository.PaymentRepository;
 import com.team3.airdnd.reservation.domain.Reservation;
 import com.team3.airdnd.reservation.domain.ReservedDate;
+
 import com.team3.airdnd.reservation.dto.ReservationRequestDto;
 import com.team3.airdnd.reservation.dto.ReservationResponseDto;
+import com.team3.airdnd.reservation.query.ReservationQueryRepository;
 import com.team3.airdnd.reservation.repository.ReservationRepository;
 import com.team3.airdnd.reservation.repository.ReservedDateRepository;
 import com.team3.airdnd.user.domain.User;
@@ -213,5 +215,8 @@ public class ReservationService {
 			}
 		}
 	}
-
+	//게스트 예약 조회
+	//public List<GuestReservationDto> getConfirmedReservationsByGuest(Long guestId) {
+	//	return reservationQueryRepository.findConfirmedReservationsByGuestId(guestId);
+	//}
 }

--- a/backend/src/main/resources/static/payment-test.html
+++ b/backend/src/main/resources/static/payment-test.html
@@ -160,7 +160,7 @@
                 return;
             }
 
-            const clientKey = ${TOSS_CLIENT_KEY};
+            const clientKey = ""; // Toss Client Key 값
             const tossPayments = TossPayments(clientKey);
 
             const finalAmount = currentReservation.amount + Math.floor(currentReservation.amount * 0.1);


### PR DESCRIPTION
## 🔨 작업 내용
호스트용 예약 조회 기능 개발 (#30)
- 최신 순으로 숙소 예약 조회 
- 숙소 별 예약 조회

게스트용 예약 조회 기능 개발
- reservation status가 confirm인 것들만 조회

## 📝 작업 진행 방식
- 예약 조회 메서드들을 QueryDSL을 사용하여 구현
- 예약 정보 DTO (ReservationInfoDto) 를 @QueryProjection 사용하여 직접 매핑
- reservation, accommodation, storedFile, guest 엔티티 간 조인 처리
- 게스트 예약 목록 조회, 호스트 예약 목록 조회, 호스트 특정 숙소 예약 조회 기능 각각 쿼리 최적화 및 리팩토링
---

## 🏓 테스트 작업 방식
- POSTMAN으로 테스트를 진행하였습니다.

---

## 참고 사항
Reservation 엔티티에 변경 사항이 있습니다!
-> 결제 시 예약 시간이 저장될 수 있도록 createdAt 필드를 추가하였습니다.
